### PR TITLE
made changes to remove carriage returns and line feeds from PostBody …

### DIFF
--- a/PagerDuty.vbs
+++ b/PagerDuty.vbs
@@ -93,6 +93,8 @@ For Each objFile in colFiles
 			AlertFileContent.LoadFromFile(AlertFile)
 			PostBody = AlertFileContent.ReadText()
 			PostBody = Replace(PostBody, "\", "\\")
+			PostBody = Replace(PostBody,vbCr,"")
+			PostBody = Replace(PostBody,vbLf,"")
 			AlertFileContent.Close
 
 			If Err.Number <> 0 Then


### PR DESCRIPTION
…before posting to API. Presence of line feeds and carriage returns in the output text file from whatsup gold breaks JSON formatting when multiple up or down states are reported.

Please enter the commit message for your changes. Lines starting