### PR TITLE
Changed HTTP transmission class

### DIFF
--- a/PagerDuty.vbs
+++ b/PagerDuty.vbs
@@ -109,11 +109,12 @@ For Each objFile in colFiles
 			Else
 				' Send the alert file content to PagerDuty and check response
 
-				Set objHTTP = CreateObject("MSXML2.XMLHTTP.3.0")
+				Set objHTTP = CreateObject("MSXML2.ServerXMLHTTP.6.0")
 
 				Err.Clear
 				WScript.Echo "Body being sent to PagerDuty is: " & vbNewLine & PostBody
 				objHTTP.Open "POST", URL, False
+				objHTTP.setRequestHeader "Content-Type", "application/json"
 				objHTTP.Send PostBody
 
 				' Log connection failures in case the system isn't able to resolve


### PR DESCRIPTION
The MSXML2.XMLHTTP class often runs into an odd "Access is denied" issue caused by security settings.

The newer class, ServerXMLHTTP, avoids the restriction that causes these errors. It should be available on pretty much any version of Windows Server. More info:

https://support.microsoft.com/en-us/help/290761/frequently-asked-questions-about-serverxmlhttp
https://social.msdn.microsoft.com/Forums/en-US/1abda1ce-e23c-4d0e-bccd-a323aa7f2ea5/access-is-denied-while-using-microsoftxmlhttp-to-get-a-url-link-in-vbscript-help?forum=xmlandnetfx
https://support.webafrica.co.za/index.php?/Knowledgebase/Article/View/615/41/msxml3dll-error-80070005-access-is-denied---loading-xml-file